### PR TITLE
Add `crafting-recipe` to tiers

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoarmor/upgrades/Tier.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoarmor/upgrades/Tier.kt
@@ -5,6 +5,7 @@ import com.willfp.eco.core.config.interfaces.Config
 import com.willfp.eco.core.display.Display
 import com.willfp.eco.core.items.CustomItem
 import com.willfp.eco.core.items.Items
+import com.willfp.eco.core.recipe.Recipes
 import com.willfp.eco.core.recipe.recipes.ShapedCraftingRecipe
 import com.willfp.eco.core.registry.Registrable
 import com.willfp.eco.util.StringUtils
@@ -42,11 +43,6 @@ class Tier(
      * The ItemStack of the crystal.
      */
     val crystal: ItemStack
-
-    /**
-     * The crafting recipe to make the crystal.
-     */
-    val crystalRecipe: ShapedCraftingRecipe?
 
     /**
      * Item properties.
@@ -98,28 +94,17 @@ class Tier(
         ).register()
 
         if (this.craftable) {
-            val recipeOut = out.clone()
-            recipeOut.amount = this.config.getInt("crystal.giveAmount")
-            val builder = ShapedCraftingRecipe.builder(plugin, "upgrade_crystal_$id")
-                .setOutput(recipeOut)
-            val recipeStrings: List<String> = this.config.getStrings("crystal.recipe")
-            CustomItem(plugin.namespacedKeyFactory.create("upgrade_crystal_$id"), { test: ItemStack? ->
-                if (test == null) {
-                    return@CustomItem false
-                }
-                if (getCrystalTier(test) == null) {
-                    return@CustomItem false
-                }
-                this == getCrystalTier(test)
-            }, out).register()
-            for (i in 0..8) {
-                builder.setRecipePart(i, Items.lookup(recipeStrings[i]))
+            val recipeOut = out.clone().apply {
+                amount = config.getInt("crystal.giveAmount")
             }
-            crystalRecipe = builder.build()
-            crystalRecipe.register()
-        } else {
-            crystalRecipe = null
-        }
+            Recipes.createAndRegisterRecipe(
+                plugin,
+                "upgrade_crystal_$id",
+                recipeOut,
+                config.getStrings("crystal.recipe"),
+                config.getStringOrNull("crystal.crafting-permission")
+            )
+        } else null
     }
 
     /**

--- a/eco-core/core-plugin/src/main/resources/sets/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/sets/_example.yml
@@ -4,7 +4,8 @@
 # including in subfolders if you want to organize your set configs
 # _example.yml is not loaded.
 
-conditions: []
+# The effects of the set (i.e. the functionality)
+# See here: https://plugins.auxilor.io/effects/configuring-an-effect
 effects:
   - id: damage_multiplier
     args:
@@ -13,6 +14,9 @@ effects:
       - melee_attack
       - bow_attack
       - trident_attack
+      -
+        # The effects of the set (i.e. the functionality)
+      # See here: https://plugins.auxilor.io/effects/configuring-an-effect
 advancedEffects:
   - id: damage_multiplier
     args:
@@ -26,81 +30,97 @@ advancedEffects:
       multiplier: 0.9
     triggers:
       - take_damage
+
 sounds:
   equip:
-    enabled: false
-    sound: ""
+    enabled: false # If a sound should play when armor is equipped.
+    sound: "" # The sound to play, sounds: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html
     volume: 1
     pitch: 1
   advancedEquip:
-    enabled: false
-    sound: ""
+    enabled: false # If a sound should play when advanced armor is equipped.
+    sound: "" # The sound to play, sounds: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html
     volume: 1
     pitch: 1
   unequip:
-    enabled: false
-    sound: ""
+    enabled: false # If a sound should play when armor is unequipped.
+    sound: "" # The sound to play, sounds: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html
     volume: 1
     pitch: 1
-advancedLore:
+
+advancedLore: # Lore to be added to the armor piece when it has been advanced.
   - ''
   - "<gradient:f12711>&lADVANCED BONUS</gradient:f5af19>"
   - "&8» &6Take 10% less damage"
   - "&8&oRequires full set to be worn"
+
 shard:
-  item: prismarine_shard unbreaking:1 hide_enchants
-  name: "<GRADIENT:f12711>Advancement Shard:</GRADIENT:f5af19> &cReaper"
-  lore:
+  item: prismarine_shard unbreaking:1 hide_enchants # The shard item, read more here: https://plugins.auxilor.io/all-plugins/the-item-lookup-system
+  name: "<GRADIENT:f12711>Advancement Shard:</GRADIENT:f5af19> &cReaper" # The in-game name of the shard.
+  lore: # The lore shown in-game on the shard. Set to `lore: []` to remove lore.
     - "&8Drop this onto &cReaper Armor"
     - "&8to make it <GRADIENT:f12711>Advanced</GRADIENT:f5af19>."
-  craftable: false
-  crafting-permission: "permission" # (Optional: Require a permission to craft this item) 
-  recipe:
+  craftable: false # If the shard is craftable
+  crafting-permission: "permission" # (Optional) The permission required to craft this recipe.
+  recipe: # The recipe, read here for more: https://plugins.auxilor.io/all-plugins/the-item-lookup-system#crafting-recipes
     - prismarine_shard
     - ecoarmor:set_reaper_helmet
     - prismarine_shard
+
     - ecoarmor:set_reaper_chestplate
     - nether_star
     - ecoarmor:set_reaper_leggings
+
     - prismarine_shard
     - ecoarmor:set_reaper_boots
     - prismarine_shard
+
 helmet:
-  item: leather_helmet color:#303030 hide_dye
-  name: "&cReaper Helmet"
-  advancedName: "<GRADIENT:f12711>Advanced</GRADIENT:f5af19>&c Reaper Helmet"
-  effectiveDurability: 2048
-  effects: []
-  advancedEffects: []
-  conditions: []
-  lore:
+  item: leather_helmet color:#303030 hide_dye # https://plugins.auxilor.io/all-plugins/the-item-lookup-system
+  name: "&cReaper Helmet" # The name shown in-game.
+  advancedName: "<GRADIENT:f12711>Advanced</GRADIENT:f5af19>&c Reaper Helmet" # The advanced name shown in-game.
+  lore: # The lore shown in-game. Set to `lore: []` to remove lore.
     - "&c&lREAPER SET BONUS"
     - "&8» &cDeal 25% more damage"
     - "&8&oRequires full set to be worn"
     - ''
     - "&fTier: %tier%"
     - "&8&oUpgrade with an Upgrade Crystal"
-  craftable: true
-  crafting-permission: "permission" # (Optional: Require a permission to craft this item)
-  defaultTier: default
-  recipe:
+  craftable: true # If the armor piece is craftable
+  crafting-permission: "permission" # (Optional) The permission required to craft this recipe.
+  recipe: # The recipe, read here for more: https://plugins.auxilor.io/all-plugins/the-item-lookup-system#crafting-recipes
     - ecoitems:armor_core ? air
     - nether_star
     - ecoitems:armor_core ? air
+
     - nether_star
     - netherite_helmet
     - nether_star
+
     - air
     - nether_star
     - air
+  defaultTier: default # The default tier of the armor
+
+  # The actual item durability isn't set (because it can't be changed), but instead
+  # this scales how quickly the item wears to act as if it had this durability.
+  # For example, let's say the actual durability is 350, but you set this to 700,
+  # it will wear at half the normal rate.
+
+  effectiveDurability: 2048  # Optional, set the durability
+
+  # The effects of the item (i.e. the functionality)
+  # See here: https://plugins.auxilor.io/effects/configuring-an-effect
+  effects: []
+  advancedEffects: []
+
+  # The conditions required for the effects to activate
+  conditions: [] # The conditions for the effects to be ru
+
 chestplate:
   item: leather_chestplate color:#303030 hide_dye
   name: "&cReaper Chestplate"
   advancedName: "<GRADIENT:f12711>Advanced</GRADIENT:f5af19>&c Reaper Chestplate"
-  effectiveDurability: 2048
-  effects: []
-  advancedEffects: []
-  conditions: []
   lore:
     - "&c&lREAPER SET BONUS"
     - "&8» &cDeal 25% more damage"
@@ -109,27 +129,29 @@ chestplate:
     - "&fTier: %tier%"
     - "&8&oUpgrade with an Upgrade Crystal"
   craftable: true
-  crafting-permission: "permission" # (Optional: Require a permission to craft this item) # (Optional: Require a permission to craft this item)
-  defaultTier: default
+  crafting-permission: "permission"
   recipe:
     - ecoitems:armor_core ? air
     - nether_star
     - ecoitems:armor_core ? air
+
     - nether_star
     - netherite_chestplate
     - nether_star
+
     - air
     - nether_star
     - air
+  defaultTier: default
+  effectiveDurability: 2048
+  effects: []
+  advancedEffects: []
+  conditions: []
+
 elytra:
   item: elytra
   name: "&cReaper Elytra"
   advancedName: "<GRADIENT:f12711>Advanced</GRADIENT:f5af19>&c Reaper Elytra"
-  effectiveDurability: 2048
-  effects: []
-  advancedEffects: []
-  crafting-permission: "permission" # (Optional: Require a permission to craft this item)
-  conditions: []
   lore:
     - "&c&lREAPER SET BONUS"
     - "&8» &cDeal 25% more damage"
@@ -138,25 +160,29 @@ elytra:
     - "&fTier: %tier%"
     - "&8&oUpgrade with an Upgrade Crystal"
   craftable: true
-  defaultTier: default
+  crafting-permission: "permission"
   recipe:
     - ecoitems:armor_core ? air
     - nether_star
     - ecoitems:armor_core ? air
+
     - nether_star
     - elytra
     - nether_star
+
     - air
     - nether_star
     - air
+  defaultTier: default
+  effectiveDurability: 2048
+  effects: []
+  advancedEffects: []
+  conditions: []
+
 leggings:
   item: leather_leggings color:#303030 hide_dye
   name: "&cReaper Leggings"
   advancedName: "<GRADIENT:f12711>Advanced</GRADIENT:f5af19>&c Reaper Leggings"
-  effectiveDurability: 2048
-  effects: []
-  advancedEffects: []
-  conditions: []
   lore:
     - "&c&lREAPER SET BONUS"
     - "&8» &cDeal 25% more damage"
@@ -165,26 +191,29 @@ leggings:
     - "&fTier: %tier%"
     - "&8&oUpgrade with an Upgrade Crystal"
   craftable: true
-  crafting-permission: "permission" # (Optional: Require a permission to craft this item)
-  defaultTier: default
+  crafting-permission: "permission"
   recipe:
     - ecoitems:armor_core ? air
     - nether_star
     - ecoitems:armor_core ? air
+
     - nether_star
     - netherite_leggings
     - nether_star
+
     - air
     - nether_star
     - air
+  defaultTier: default
+  effectiveDurability: 2048
+  effects: []
+  advancedEffects: []
+  conditions: []
+
 boots:
   item: leather_boots color:#303030 hide_dye
   name: "&cReaper Boots"
   advancedName: "<GRADIENT:f12711>Advanced</GRADIENT:f5af19>&c Reaper Boots"
-  effectiveDurability: 2048
-  effects: []
-  advancedEffects: []
-  conditions: []
   lore:
     - "&c&lREAPER SET BONUS"
     - "&8» &cDeal 25% more damage"
@@ -193,15 +222,21 @@ boots:
     - "&fTier: %tier%"
     - "&8&oUpgrade with an Upgrade Crystal"
   craftable: true
-  crafting-permission: "permission" # (Optional: Require a permission to craft this item)
-  defaultTier: default
+  crafting-permission: "permission"
   recipe:
     - ecoitems:armor_core ? air
     - nether_star
     - ecoitems:armor_core ? air
+
     - nether_star
     - netherite_boots
     - nether_star
+
     - air
     - nether_star
     - air
+  defaultTier: default
+  effectiveDurability: 2048
+  effects: []
+  advancedEffects: []
+  conditions: []

--- a/eco-core/core-plugin/src/main/resources/tiers/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/_example.yml
@@ -5,14 +5,22 @@
 # _example.yml is not loaded.
 
 id: netherite
-display: "&c&lNETHERITE"
-requiresTiers:
-  - diamond
+display: "&c&lNETHERITE" # The display in-game
+requiresTiers: # If this tier requires a prior tier
+  - diamond # Tier ID
+  - iron
 crystal:
-  item: end_crystal
-  name: "&cNetherite Upgrade Crystal"
-  craftable: true
-  recipe:
+  item: end_crystal # The crystal item, read more here: https://plugins.auxilor.io/all-plugins/the-item-lookup-system
+  name: "&cNetherite Upgrade Crystal" # The name shown in-game.
+  lore: # The lore shown in-game. Set to `lore: []` to remove lore.
+    - "&8Drop this onto an armor piece"
+    - "&8to set its tier to:"
+    - "&c&lNETHERITE"
+    - ''
+    - "&8&oRequires the armor to already have Diamond tier"
+  craftable: true # If the armor piece is craftable
+  crafting-permission: "permission" # (Optional) The permission required to craft this recipe.
+  recipe: # The recipe, read here for more: https://plugins.auxilor.io/all-plugins/the-item-lookup-system#crafting-recipes
     - air
     - netherite_ingot
     - air
@@ -22,22 +30,16 @@ crystal:
     - air
     - netherite_ingot
     - air
-  giveAmount: 1
-  lore:
-    - "&8Drop this onto an armor piece"
-    - "&8to set its tier to:"
-    - "&c&lNETHERITE"
-    - ''
-    - "&8&oRequires the armor to already have Diamond tier"
+  giveAmount: 1 # Optional, set the amount of items to give in the recipe
 properties:
   helmet:
-    armor: 3
-    toughness: 3
-    knockbackResistance: 1
-    speedPercentage: 0
-    attackSpeedPercentage: 0
-    attackDamagePercentage: 0
-    attackKnockbackPercentage: 0
+    armor: 3 # The armor attribute
+    toughness: 3 # the toughness attribute
+    knockbackResistance: 1 # The knockback resistance attribute
+    speedPercentage: 0 # The movement speed attribute
+    attackSpeedPercentage: 0 # The attack speed attribute
+    attackDamagePercentage: 0 # The damage attribute
+    attackKnockbackPercentage: 0 # The knockback attribute
   chestplate:
     armor: 8
     toughness: 3
@@ -69,4 +71,4 @@ properties:
     speedPercentage: 0
     attackSpeedPercentage: 0
     attackDamagePercentage: 0
-    attackKnockbackPercentage: 0
+    attackKnockbackPercentage: 0: 0

--- a/eco-core/core-plugin/src/main/resources/tiers/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/_example.yml
@@ -4,7 +4,6 @@
 # including in subfolders if you want to organize your tier configs
 # _example.yml is not loaded.
 
-id: netherite
 display: "&c&lNETHERITE" # The display in-game
 requiresTiers: # If this tier requires a prior tier
   - diamond # Tier ID

--- a/eco-core/core-plugin/src/main/resources/tiers/ancient.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/ancient.yml
@@ -1,4 +1,3 @@
-id: ancient
 display: "&6&k!!&r <GRADIENT:ffb347>&lANCIENT</GRADIENT:ffcc33>&r &6&k!!&r"
 requiresTiers: []
 crystal:

--- a/eco-core/core-plugin/src/main/resources/tiers/cobalt.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/cobalt.yml
@@ -1,4 +1,3 @@
-id: cobalt
 display: "&#0047ab&lCOBALT"
 requiresTiers:
   - iron

--- a/eco-core/core-plugin/src/main/resources/tiers/default.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/default.yml
@@ -1,4 +1,3 @@
-id: default
 display: "&8&lDEFAULT"
 requiresTiers: []
 crystal:

--- a/eco-core/core-plugin/src/main/resources/tiers/diamond.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/diamond.yml
@@ -1,4 +1,3 @@
-id: diamond
 display: "&b&lDIAMOND"
 requiresTiers:
   - iron

--- a/eco-core/core-plugin/src/main/resources/tiers/exotic.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/exotic.yml
@@ -1,4 +1,3 @@
-id: exotic
 display: "&6&k!!&r <GRADIENT:f79d00>&lEXOTIC</GRADIENT:64f38c>&r &6&k!!&r"
 requiresTiers:
   - netherite

--- a/eco-core/core-plugin/src/main/resources/tiers/iron.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/iron.yml
@@ -1,4 +1,3 @@
-id: iron
 display: "&7&lIRON"
 requiresTiers:
   - default

--- a/eco-core/core-plugin/src/main/resources/tiers/manyullyn.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/manyullyn.yml
@@ -1,4 +1,3 @@
-id: manyullyn
 display: "&d&k!!&r <GRADIENT:f953c6>&lMANYULLYN</GRADIENT:b91d73>&r &d&k!!&r"
 requiresTiers:
   - netherite

--- a/eco-core/core-plugin/src/main/resources/tiers/mythic.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/mythic.yml
@@ -1,4 +1,3 @@
-id: mythic
 display: "&1&k!!&r <GRADIENT:00c6ff>&lMYTHIC</GRADIENT:0072ff>&r &1&k!!&r"
 requiresTiers: []
 crystal:

--- a/eco-core/core-plugin/src/main/resources/tiers/netherite.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/netherite.yml
@@ -1,4 +1,3 @@
-id: netherite
 display: "&c&lNETHERITE"
 requiresTiers:
   - diamond

--- a/eco-core/core-plugin/src/main/resources/tiers/osmium.yml
+++ b/eco-core/core-plugin/src/main/resources/tiers/osmium.yml
@@ -1,4 +1,3 @@
-id: osmium
 display: "&b&k!!&r <GRADIENT:c7f1ff>&lOSMIUM</GRADIENT:5c92ff>&r &b&k!!"
 requiresTiers:
   - cobalt


### PR DESCRIPTION
adds crafting-recipe to tier crystals, like exists in sets, shards, ecoitems etc. 
Refactored what seems to be dated crafting logic into the logic shared in other EcoPlugins and craftable items within EcoArmor

I have tested this and appears to be working as expected and no console errors.