### PR TITLE
feat: Allow disabling elytra per armor set

### DIFF
--- a/documentation/ecoarmor/how-to-make-a-custom-set.md
+++ b/documentation/ecoarmor/how-to-make-a-custom-set.md
@@ -300,8 +300,19 @@ helmet:
   conditions: [] # Conditions required for this piece's effects to run
 ```
 
-:::danger The elytra is required
-All five pieces, including the elytra, must be present. Removing the elytra block is the most common cause of a set spawning a block of stone. If you don't want players to use the elytra, leave the block in and give individual pieces with commands instead.
+:::danger The elytra block is required
+All five pieces, including the elytra, must be present. Removing the elytra block is the most common cause of a set spawning a block of stone.
+
+If you don't want a set to have an elytra, **don't delete the block** — instead set `enabled: false` inside it:
+
+```yaml
+elytra:
+  enabled: false # No elytra piece for this set.
+  item: elytra
+  # ...the rest of the block can stay as-is, it's ignored while disabled.
+```
+
+With `enabled: false`, the elytra piece can't be crafted, and `/ecoarmor give <player> set:<id> full` (or giving with no slot at all) skips it automatically.
 :::
 
 ## Internal placeholders

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoarmor/commands/CommandGive.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoarmor/commands/CommandGive.kt
@@ -98,12 +98,16 @@ object CommandGive : Subcommand(
                     }
                 }
                 if (slot == null) {
-                    slots.addAll(ArmorSlot.entries)
+                    slots.addAll(ArmorSlot.entries.filter { it != ArmorSlot.ELYTRA || set.elytraEnabled })
                 } else {
+                    if (slot == ArmorSlot.ELYTRA && !set.elytraEnabled) {
+                        sender.sendMessage(plugin.langYml.getMessage("invalid-item"))
+                        return
+                    }
                     slots.add(slot)
                 }
             } else {
-                slots.addAll(ArmorSlot.entries)
+                slots.addAll(ArmorSlot.entries.filter { it != ArmorSlot.ELYTRA || set.elytraEnabled })
             }
             if (args.size >= 4) {
                 advanced = args[3].toBoolean()
@@ -189,7 +193,13 @@ object CommandGive : Subcommand(
         }
         if (args[1].startsWith("set:")) {
             if (args.size == 3) {
-                StringUtil.copyPartialMatches(args[2], slots, completions)
+                val set = ArmorSets.getByID(args[1].removePrefix("set:"))
+                val availableSlots = if (set != null && !set.elytraEnabled) {
+                    slots.filter { !it.equals("elytra", ignoreCase = true) }
+                } else {
+                    slots
+                }
+                StringUtil.copyPartialMatches(args[2], availableSlots, completions)
                 completions.sort()
                 return completions
             }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoarmor/sets/ArmorSet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoarmor/sets/ArmorSet.kt
@@ -69,6 +69,10 @@ class ArmorSet(
         else if (config.has("fullSetDisablesPartialSet")) config.getBool("fullSetDisablesPartialSet")
         else true
 
+    /** Whether this set has an elytra piece. Defaults to true to keep existing sets working. */
+    val elytraEnabled: Boolean =
+        if (config.has("elytra.enabled")) config.getBool("elytra.enabled") else true
+
     val partialHolders = notNullMutableMapOf<Int, Holder>()
 
     /** Create a new Armor Set. */
@@ -112,7 +116,9 @@ class ArmorSet(
             val slotConfig = config.getSubsection(slot.name.lowercase(Locale.ENGLISH))
             val item = construct(slot, slotConfig, false)
             items[slot] = item
-            constructRecipe(slot, slotConfig, item)
+            if (slot != ArmorSlot.ELYTRA || elytraEnabled) {
+                constructRecipe(slot, slotConfig, item)
+            }
             val advancedItem = construct(slot, slotConfig, true)
             advancedItems[slot] = advancedItem
 

--- a/eco-core/core-plugin/src/main/resources/sets/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/sets/_example.yml
@@ -179,6 +179,7 @@ chestplate:
   conditions: []
 
 elytra:
+  enabled: true # If false, this set has no elytra piece: it won't be craftable, and `/ecoarmor give <player> set:<id> full` will skip it.
   item: elytra
   name: "&cReaper Elytra"
   advancedName: "<GRADIENT:f12711>Advanced</GRADIENT:f5af19>&c Reaper Elytra"


### PR DESCRIPTION
Sets can now set elytra.enabled: false to drop the elytra piece without breaking the config (previously the elytra block was mandatory and removing it broke the set). When elytra is disabled, it can no longer be crafted, and /ecoarmor give set:<id> (full or no slot) skips the elytra piece instead of always including it. By default to preserve existing set the elytra is enabled if the boolean is not present in configuration.